### PR TITLE
feat(grid-demo): add angular column dom performance demo

### DIFF
--- a/grid-demo/src/app/angular/column-dom-performance/column-dom-performance.component.html
+++ b/grid-demo/src/app/angular/column-dom-performance/column-dom-performance.component.html
@@ -1,1 +1,20 @@
-Angular - Column DOM Performance
+<clr-datagrid *ngIf="{ vms: vms | async }; let data" [clrDgLoading]="data.vms === null">
+  <clr-dg-column *ngFor="let column of columns" [clrDgField]="column.field">
+    <ng-template [clrDgHideableColumn]="{ hidden: column.hidden }" (clrDgHiddenChange)="column.hidden = $event">
+      {{ column.displayName }}
+    </ng-template>
+  </clr-dg-column>
+
+  <clr-dg-row *clrDgItems="let vm of data.vms!" [clrDgItem]="vm">
+    <clr-dg-cell *ngFor="let column of columns">
+      <ng-container *ngIf="!column.hidden">{{ vm[column.field] }}</ng-container>
+    </clr-dg-cell>
+  </clr-dg-row>
+
+  <clr-dg-footer>
+    <clr-dg-pagination #pagination>
+      <clr-dg-page-size [clrPageSizeOptions]="[10, 20, 50, 100]"> Elements per page </clr-dg-page-size>
+      {{ pagination.firstItem + 1 }} - {{ pagination.lastItem + 1 }} of {{ pagination.totalItems }} elements
+    </clr-dg-pagination>
+  </clr-dg-footer>
+</clr-datagrid>

--- a/grid-demo/src/app/angular/column-dom-performance/column-dom-performance.component.ts
+++ b/grid-demo/src/app/angular/column-dom-performance/column-dom-performance.component.ts
@@ -1,7 +1,18 @@
 import { Component } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { Vm, generateVms, columns } from './../../data/vm.generator';
 
 @Component({
   templateUrl: './column-dom-performance.component.html',
   styleUrls: ['./column-dom-performance.component.scss'],
 })
-export class AngularColumnDomPerformanceComponent {}
+export class AngularColumnDomPerformanceComponent {
+  readonly vms: Observable<Vm[]>;
+  readonly columns = columns.map(column => ({ ...column, hidden: false }));
+
+  constructor() {
+    this.vms = generateVms({ pageIndex: 0, pageSize: 1000 }).pipe(map(data => data.vms));
+  }
+}


### PR DESCRIPTION
This requires some application logic for tracking which columns are hidden, but it can be pretty minimal depending on how you structure your grid.

I can't seem to find a way to remove the `clr-dg-cell` elements from the DOM without breaking the grid column width logic in one way or another. Bu rendering the contents of the cell only if the column is shown is relatively straightforward.