### PR TITLE
chore(grid-demo): rename advanced selection directive with custom prefix

### DIFF
--- a/grid-demo/src/app/angular/advanced-row-selection/advanced-row-selection.component.html
+++ b/grid-demo/src/app/angular/advanced-row-selection/advanced-row-selection.component.html
@@ -1,10 +1,6 @@
 <div>Requires ^13.5.0 or ^12.3.0</div>
 
-<clr-datagrid
-  *ngIf="{ vms: vms | async }; let data"
-  [clrDgLoading]="data.vms === null"
-  clrAdvancedSelection
->
+<clr-datagrid *ngIf="{ vms: vms | async }; let data" [clrDgLoading]="data.vms === null" clrAdvancedSelection>
   <clr-dg-column *ngFor="let column of columns" [clrDgField]="column.field">
     <ng-container *clrDgHideableColumn>{{ column.displayName }}</ng-container>
   </clr-dg-column>

--- a/grid-demo/src/app/angular/advanced-row-selection/advanced-row-selection.component.html
+++ b/grid-demo/src/app/angular/advanced-row-selection/advanced-row-selection.component.html
@@ -1,6 +1,6 @@
 <div>Requires ^13.5.0 or ^12.3.0</div>
 
-<clr-datagrid *ngIf="{ vms: vms | async }; let data" [clrDgLoading]="data.vms === null" clrAdvancedSelection>
+<clr-datagrid *ngIf="{ vms: vms | async }; let data" [clrDgLoading]="data.vms === null" customClrAdvancedSelection>
   <clr-dg-column *ngFor="let column of columns" [clrDgField]="column.field">
     <ng-container *clrDgHideableColumn>{{ column.displayName }}</ng-container>
   </clr-dg-column>

--- a/grid-demo/src/app/angular/advanced-row-selection/clr-advanced-selection.directive.ts
+++ b/grid-demo/src/app/angular/advanced-row-selection/clr-advanced-selection.directive.ts
@@ -4,7 +4,7 @@ import { ClrDatagrid } from '@clr/angular';
 @Directive({
   selector: 'clr-datagrid[clrAdvancedSelection]',
 })
-export class AdvancedSelectionDirective implements OnInit {
+export class ClrAdvancedSelectionDirective implements OnInit {
   constructor(private readonly elementRef: ElementRef, private readonly datagrid: ClrDatagrid) {}
 
   ngOnInit() {

--- a/grid-demo/src/app/angular/advanced-row-selection/custom-clr-advanced-selection.directive.ts
+++ b/grid-demo/src/app/angular/advanced-row-selection/custom-clr-advanced-selection.directive.ts
@@ -2,9 +2,9 @@ import { Directive, ElementRef, HostListener, OnInit } from '@angular/core';
 import { ClrDatagrid } from '@clr/angular';
 
 @Directive({
-  selector: 'clr-datagrid[clrAdvancedSelection]',
+  selector: 'clr-datagrid[customClrAdvancedSelection]',
 })
-export class ClrAdvancedSelectionDirective implements OnInit {
+export class CustomClrAdvancedSelectionDirective implements OnInit {
   constructor(private readonly elementRef: ElementRef, private readonly datagrid: ClrDatagrid) {}
 
   ngOnInit() {

--- a/grid-demo/src/app/app.module.ts
+++ b/grid-demo/src/app/app.module.ts
@@ -15,7 +15,7 @@ import { CoreColumnDomPerformanceComponent } from './core/column-dom-performance
 import { CoreColumnOrderingComponent } from './core/column-ordering/column-ordering.component';
 import { CoreLazyLoadingRowsComponent } from './core/lazy-loading-rows/lazy-loading-rows.component';
 import { CoreRowDomPerformanceComponent } from './core/row-dom-performance/row-dom-performance.component';
-import { AdvancedSelectionDirective } from './angular/advanced-row-selection/advanced-selection.directive';
+import { ClrAdvancedSelectionDirective } from './angular/advanced-row-selection/clr-advanced-selection.directive';
 
 loadCoreIconSet();
 loadEssentialIconSet();
@@ -34,7 +34,7 @@ const components = [
   CoreRowDomPerformanceComponent,
 ];
 
-const directives = [AdvancedSelectionDirective];
+const directives = [ClrAdvancedSelectionDirective];
 
 @NgModule({
   declarations: [...components, ...directives],

--- a/grid-demo/src/app/app.module.ts
+++ b/grid-demo/src/app/app.module.ts
@@ -15,7 +15,7 @@ import { CoreColumnDomPerformanceComponent } from './core/column-dom-performance
 import { CoreColumnOrderingComponent } from './core/column-ordering/column-ordering.component';
 import { CoreLazyLoadingRowsComponent } from './core/lazy-loading-rows/lazy-loading-rows.component';
 import { CoreRowDomPerformanceComponent } from './core/row-dom-performance/row-dom-performance.component';
-import { ClrAdvancedSelectionDirective } from './angular/advanced-row-selection/clr-advanced-selection.directive';
+import { CustomClrAdvancedSelectionDirective } from './angular/advanced-row-selection/custom-clr-advanced-selection.directive';
 
 loadCoreIconSet();
 loadEssentialIconSet();
@@ -34,7 +34,7 @@ const components = [
   CoreRowDomPerformanceComponent,
 ];
 
-const directives = [ClrAdvancedSelectionDirective];
+const directives = [CustomClrAdvancedSelectionDirective];
 
 @NgModule({
   declarations: [...components, ...directives],


### PR DESCRIPTION
This makes it more clear which things are from Clarity and which things are custom for the demo.