### PR TITLE
feat: add reorder column demo (angular)

### DIFF
--- a/grid-demo/src/app/angular/column-ordering/column-ordering.component.html
+++ b/grid-demo/src/app/angular/column-ordering/column-ordering.component.html
@@ -1,21 +1,23 @@
 <clr-datagrid
-  *ngIf="{ vms: vms | async, columns: columns | async }; let data"
+  id="grid"
+  *ngIf="{ vms: vms | async }; let data"
   [clrDgLoading]="data.vms === null"
-  (cdkDropListDropped)="columnDropped($event)"
   cdkDropList
-  cdkDropListOrientation="horizontal"
+  customClrColumnOrderingGrid
+  [(columns)]="columns"
 >
   <clr-dg-column
-    *ngFor="let column of data.columns"
+    *ngFor="let column of columns; let index = index"
     [clrDgField]="column.field"
     cdkDrag
-    cdkDragPreviewContainer="parent"
+    [customClrColumnOrderingColumn]="column"
+    [columnIndex]="index"
   >
     <ng-container *clrDgHideableColumn>{{ column.displayName }}</ng-container>
   </clr-dg-column>
 
   <clr-dg-row *clrDgItems="let vm of data.vms!" [clrDgItem]="vm">
-    <clr-dg-cell *ngFor="let column of data.columns">{{ vm[column.field] }}</clr-dg-cell>
+    <clr-dg-cell *ngFor="let column of columns">{{ vm[column.field] }}</clr-dg-cell>
   </clr-dg-row>
 
   <clr-dg-footer>

--- a/grid-demo/src/app/angular/column-ordering/column-ordering.component.scss
+++ b/grid-demo/src/app/angular/column-ordering/column-ordering.component.scss
@@ -1,0 +1,3 @@
+.grabbed {
+  background-color: rgba(0, 114, 163, 0.5);
+}

--- a/grid-demo/src/app/angular/column-ordering/column-ordering.component.ts
+++ b/grid-demo/src/app/angular/column-ordering/column-ordering.component.ts
@@ -1,6 +1,5 @@
-import { CdkDragDrop } from '@angular/cdk/drag-drop';
 import { Component } from '@angular/core';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { Vm, generateVms, columns } from './../../data/vm.generator';
@@ -11,17 +10,9 @@ import { Vm, generateVms, columns } from './../../data/vm.generator';
 })
 export class AngularColumnOrderingComponent {
   readonly vms: Observable<Vm[]>;
-  readonly columns = new BehaviorSubject<{ field: keyof Vm; displayName: string }[]>(columns);
+  columns = columns;
 
   constructor() {
     this.vms = generateVms({ pageIndex: 0, pageSize: 1000 }).pipe(map(data => data.vms));
-  }
-
-  columnDropped(event: CdkDragDrop<Vm[]>) {
-    const value = [...this.columns.value];
-    const temp = value[event.currentIndex];
-    value[event.currentIndex] = value[event.previousIndex];
-    value[event.previousIndex] = temp;
-    this.columns.next(value);
   }
 }

--- a/grid-demo/src/app/angular/column-ordering/custom-clr-column-ordering-column.directive.ts
+++ b/grid-demo/src/app/angular/column-ordering/custom-clr-column-ordering-column.directive.ts
@@ -1,0 +1,54 @@
+import { CdkDrag } from '@angular/cdk/drag-drop';
+import { Directive, ElementRef, EventEmitter, HostBinding, HostListener, Input, Output } from '@angular/core';
+import { ClrDatagrid } from '@clr/angular';
+import { CustomClrColumnOrderingGridDirective } from './custom-clr-column-ordering-grid.directive';
+
+@Directive({
+  selector: 'clr-dg-column[customClrColumnOrderingColumn]',
+})
+export class CustomClrColumnOrderingColumnDirective {
+  constructor(
+    private readonly gridDirective: CustomClrColumnOrderingGridDirective,
+    private readonly datagrid: ClrDatagrid,
+    private readonly elementRef: ElementRef,
+    cdkDrag: CdkDrag
+  ) {
+    cdkDrag.previewContainer = 'parent';
+  }
+
+  @Input() customClrColumnOrderingColumn: any;
+  @Input() columnIndex!: number;
+  @HostBinding('class.grabbed') get isGrabbed() {
+    return this.gridDirective.grabbedColumn === this.customClrColumnOrderingColumn;
+  }
+
+  @HostListener('keydown', ['$event']) keydown(event: KeyboardEvent) {
+    const isSpace = event.code === 'Space';
+    const isLeft = event.code === 'ArrowLeft';
+    const isRight = event.code === 'ArrowRight';
+
+    if (isSpace || (this.gridDirective.grabbedColumn && (isLeft || isRight))) {
+      event.stopImmediatePropagation();
+      event.preventDefault();
+
+      if (isSpace) {
+        this.gridDirective.grabbedColumn =
+          this.gridDirective.grabbedColumn === this.customClrColumnOrderingColumn
+            ? null
+            : this.customClrColumnOrderingColumn;
+      } else if (this.gridDirective.grabbedColumn) {
+        const newIndex = isLeft
+          ? Math.max(0, this.columnIndex - 1)
+          : Math.min(this.datagrid.columns.length - 1, this.columnIndex + 1);
+        this.gridDirective.reorderColumn({ previousIndex: this.columnIndex, currentIndex: newIndex });
+        this.setActiveCell();
+      }
+    }
+  }
+
+  private setActiveCell() {
+    setTimeout(() => {
+      (this.datagrid as any).keyNavigation.setActiveCell(this.elementRef.nativeElement);
+    });
+  }
+}

--- a/grid-demo/src/app/angular/column-ordering/custom-clr-column-ordering-grid.directive.ts
+++ b/grid-demo/src/app/angular/column-ordering/custom-clr-column-ordering-grid.directive.ts
@@ -1,0 +1,40 @@
+import { CdkDropList, moveItemInArray } from '@angular/cdk/drag-drop';
+import { Directive, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { tap } from 'rxjs/operators';
+
+@Directive({
+  selector: 'clr-datagrid[customClrColumnOrderingGrid]',
+})
+export class CustomClrColumnOrderingGridDirective implements OnInit, OnDestroy {
+  @Input() columns!: any[];
+  @Output() columnsChange = new EventEmitter<any[]>();
+
+  grabbedColumn: any;
+  private subscription: Subscription | undefined;
+
+  constructor(private readonly cdkDropList: CdkDropList) {}
+
+  ngOnInit(): void {
+    this.cdkDropList.orientation = 'horizontal';
+    this.subscription = this.cdkDropList.dropped
+      .pipe(
+        tap(event => {
+          this.reorderColumn(event);
+        })
+      )
+      .subscribe();
+  }
+
+  ngOnDestroy(): void {
+    this.subscription?.unsubscribe();
+  }
+
+  reorderColumn(event: { previousIndex: number; currentIndex: number }) {
+    if (event.currentIndex !== event.previousIndex) {
+      const value = [...this.columns];
+      moveItemInArray(value, event.previousIndex, event.currentIndex);
+      this.columnsChange.emit(value);
+    }
+  }
+}

--- a/grid-demo/src/app/app.module.ts
+++ b/grid-demo/src/app/app.module.ts
@@ -19,6 +19,8 @@ import { CoreColumnOrderingComponent } from './core/column-ordering/column-order
 import { CoreLazyLoadingRowsComponent } from './core/lazy-loading-rows/lazy-loading-rows.component';
 import { CoreRowDomPerformanceComponent } from './core/row-dom-performance/row-dom-performance.component';
 import { CustomClrAdvancedSelectionDirective } from './angular/advanced-row-selection/custom-clr-advanced-selection.directive';
+import { CustomClrColumnOrderingGridDirective } from './angular/column-ordering/custom-clr-column-ordering-grid.directive';
+import { CustomClrColumnOrderingColumnDirective } from './angular/column-ordering/custom-clr-column-ordering-column.directive';
 
 loadCoreIconSet();
 loadEssentialIconSet();
@@ -37,7 +39,11 @@ const components = [
   CoreRowDomPerformanceComponent,
 ];
 
-const directives = [CustomClrAdvancedSelectionDirective];
+const directives = [
+  CustomClrAdvancedSelectionDirective,
+  CustomClrColumnOrderingColumnDirective,
+  CustomClrColumnOrderingGridDirective,
+];
 
 @NgModule({
   declarations: [...components, ...directives],


### PR DESCRIPTION
This is a redo of the column ordering for angular demo that adds a11y keyboard support. There is a hack in this that accesses private properties of the datagrid (keyboradNavigationController). However, if we like this approach, we could always open up the API allowing us to remove this hack.