### PR TITLE
fix(grid-demo): maintain active cell in virtual rows correctly

### DIFF
--- a/grid-demo/src/app/angular/row-dom-performance/custom-clr-virtual-rows.directive.ts
+++ b/grid-demo/src/app/angular/row-dom-performance/custom-clr-virtual-rows.directive.ts
@@ -272,10 +272,8 @@ export class CustomClrVirtualRowsDirective<T> implements OnInit, DoCheck, OnDest
       event.preventDefault();
       event.stopImmediatePropagation();
 
-      const rowElements = Array.from(this.datagridElementRef.nativeElement.querySelectorAll('clr-dg-row'));
-      const activeRowElement = rowElements.find(row => row.contains(this.activeCellElement!));
-      const activeRowRoleElement = activeRowElement?.querySelector('[role="row"][aria-rowindex]');
-      const activeItemIndex = parseInt(activeRowRoleElement?.getAttribute('aria-rowindex')!) - 1;
+      const activeRowElement = this.activeCellElement.closest('[role="row"][aria-rowindex]')!;
+      const activeItemIndex = parseInt(activeRowElement?.getAttribute('aria-rowindex')!) - 1;
 
       if (!isNaN(activeItemIndex)) {
         const nextItemIndex =

--- a/grid-demo/src/app/angular/row-dom-performance/custom-clr-virtual-rows.directive.ts
+++ b/grid-demo/src/app/angular/row-dom-performance/custom-clr-virtual-rows.directive.ts
@@ -29,6 +29,11 @@ import {
 import { ClrDatagrid } from '@clr/angular';
 import { fromEvent, Subscription } from 'rxjs';
 
+interface CellCoordinates {
+  itemIndex: number;
+  columnIndex: number;
+}
+
 type CdkVirtualForInputKey =
   | 'cdkVirtualForOf'
   | 'cdkVirtualForTrackBy'
@@ -134,7 +139,7 @@ export class CustomClrVirtualRowsDirective<T> implements OnInit, DoCheck, OnDest
   private keydownEventSubscription: Subscription | undefined;
   private totalSize = 0;
   private activeCellElement: HTMLElement | undefined;
-  private nextActiveCellCoordinates: { itemIndex: number; columnIndex: number } | undefined;
+  private nextActiveCellCoordinates: CellCoordinates | undefined;
 
   constructor(
     private readonly changeDetectorRef: ChangeDetectorRef,

--- a/grid-demo/src/app/angular/row-dom-performance/custom-clr-virtual-rows.directive.ts
+++ b/grid-demo/src/app/angular/row-dom-performance/custom-clr-virtual-rows.directive.ts
@@ -274,7 +274,7 @@ export class CustomClrVirtualRowsDirective<T> implements OnInit, DoCheck, OnDest
 
       const rowElements = Array.from(this.datagridElementRef.nativeElement.querySelectorAll('clr-dg-row'));
       const activeRowElement = rowElements.find(row => row.contains(this.activeCellElement!));
-      const activeRowRoleElement = activeRowElement?.querySelector('[aria-rowindex][aria-rowindex]');
+      const activeRowRoleElement = activeRowElement?.querySelector('[role="row"][aria-rowindex]');
       const activeItemIndex = parseInt(activeRowRoleElement?.getAttribute('aria-rowindex')!) - 1;
 
       if (!isNaN(activeItemIndex)) {


### PR DESCRIPTION
closes #73

We need to track the active cell by index so that the active cell is set correctly after row elements are recycled.