### PR TITLE
chore(grid-demo): move virtual rows init code back to `ngOnInit`

### DIFF
--- a/grid-demo/src/app/angular/row-dom-performance/custom-clr-virtual-rows.directive.ts
+++ b/grid-demo/src/app/angular/row-dom-performance/custom-clr-virtual-rows.directive.ts
@@ -135,9 +135,9 @@ export class CustomClrVirtualRowsDirective<T> implements OnInit, DoCheck, OnDest
   private datagridKeyNavigationController = getDatagridKeyNavigationController(this.datagrid);
 
   private gridRoleElement: HTMLElement | null | undefined;
-  private virtualScrollStrategy: FixedSizeVirtualScrollStrategy | undefined;
-  private virtualScrollViewport: CdkVirtualScrollViewport | undefined;
-  private cdkVirtualFor: CdkVirtualForOf<T> | undefined;
+  private virtualScrollStrategy: FixedSizeVirtualScrollStrategy;
+  private virtualScrollViewport: CdkVirtualScrollViewport;
+  private cdkVirtualFor: CdkVirtualForOf<T>;
   private setActiveCellSubscription: Subscription | undefined;
   private dataStreamSubscription: Subscription | undefined;
   private renderedRangeChangeSubscription: Subscription | undefined;
@@ -157,8 +157,6 @@ export class CustomClrVirtualRowsDirective<T> implements OnInit, DoCheck, OnDest
     private readonly viewportRuler: ViewportRuler,
     private readonly datagrid: ClrDatagrid
   ) {
-    this.gridRoleElement = this.datagridElementRef.nativeElement.querySelector<HTMLElement>('[role="grid"]');
-
     this.virtualScrollStrategy = new FixedSizeVirtualScrollStrategy(
       this._cdkFixedSizeVirtualScrollInputs.itemSize,
       this._cdkFixedSizeVirtualScrollInputs.minBufferPx,
@@ -185,6 +183,10 @@ export class CustomClrVirtualRowsDirective<T> implements OnInit, DoCheck, OnDest
       this.virtualScrollViewport,
       this.ngZone
     );
+  }
+
+  ngOnInit() {
+    this.gridRoleElement = this.datagridElementRef.nativeElement.querySelector<HTMLElement>('[role="grid"]');
 
     this.updateCdkVirtualForInputs();
 
@@ -208,8 +210,6 @@ export class CustomClrVirtualRowsDirective<T> implements OnInit, DoCheck, OnDest
       this.handlePageUpAndPageDownKeys(event);
     });
   }
-
-  ngOnInit() {}
 
   ngDoCheck() {
     this.cdkVirtualFor?.ngDoCheck();


### PR DESCRIPTION
DOM queries and subscriptions should be in `ngOnInit`, not the directive constructor.

(I will change the base to `main` once my linting PR is merged.)